### PR TITLE
Fix PyPI badge using shields.io service

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # AlphaPy Pro
 
 [![Documentation](https://img.shields.io/badge/docs-github%20pages-blue)](https://scottfreellc.github.io/alphapy-pro/)
-[![PyPI version](https://badge.fury.io/py/alphapy-pro.svg)](https://pypi.org/project/alphapy-pro/)
+[![PyPI version](https://img.shields.io/pypi/v/alphapy-pro)](https://pypi.org/project/alphapy-pro/)
+[![PyPI downloads](https://img.shields.io/pypi/dm/alphapy-pro)](https://pypi.org/project/alphapy-pro/)
 [![Python 3.12+](https://img.shields.io/badge/python-3.12+-blue.svg)](https://www.python.org/downloads/)
 [![Build Status](https://github.com/ScottFreeLLC/alphapy-pro/workflows/Tests/badge.svg)](https://github.com/ScottFreeLLC/alphapy-pro/actions)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)


### PR DESCRIPTION
## Summary

Fix the PyPI badge that was showing "not found" by switching from badge.fury.io to shields.io service.

### Changes

- **Replace badge.fury.io with shields.io** for PyPI version badge
- **Add PyPI downloads badge** for better metrics visibility  
- shields.io is more reliable and updates faster than badge.fury.io
- Both badges link to PyPI package page

### Issue Fixed

The PyPI badge was showing "not found" even though the package is successfully published on PyPI. This was due to caching/reliability issues with badge.fury.io.

### Test Plan

- [x] Verified package exists on PyPI (alphapy-pro v3.0.0)
- [x] Tested new badge URLs work correctly
- [x] Both badges link to correct PyPI page
- [x] All other badges remain functional

### Type of Change

- [ ] Bug fix
- [x] Documentation update  
- [ ] New feature
- [ ] Breaking change

---

🤖 Generated with [Claude Code](https://claude.ai/code)