### PR TITLE
Fix regression CV + polars/pandas mixing in transforms pipeline

### DIFF
--- a/alphapy/features.py
+++ b/alphapy/features.py
@@ -210,7 +210,12 @@ def apply_transforms(model, X):
                 features = apply_transform(f_latest, X, transforms[fname])
                 if features is not None:
                     if features.shape[0] == X.shape[0]:
-                        all_features = pd.concat([all_features, features], axis=1)
+                        if hasattr(all_features, "to_pandas"):
+                            # X is polars; coerce features to polars too
+                            features_pl = pl.from_pandas(features) if isinstance(features, pd.DataFrame) else features
+                            all_features = pl.concat([all_features, features_pl], how="horizontal")
+                        else:
+                            all_features = pd.concat([all_features, features], axis=1)
                     else:
                         raise IndexError("The number of transform rows [%d] must match X [%d]" %
                                          (features.shape[0], X.shape[0]))

--- a/alphapy/model.py
+++ b/alphapy/model.py
@@ -83,6 +83,7 @@ from sklearn.metrics import r2_score
 from sklearn.metrics import recall_score
 from sklearn.metrics import roc_curve
 from sklearn.model_selection import cross_val_score
+from sklearn.model_selection import KFold
 from sklearn.model_selection import StratifiedKFold
 from sklearn.model_selection import train_test_split
 import sys
@@ -771,9 +772,12 @@ def first_fit(model, algo, est):
 
     if model_type != ModelType.ranking:
         logger.info("Cross-Validation")
-        strat_k_fold = StratifiedKFold(n_splits=cv_folds, shuffle=shuffle)
+        if model_type == ModelType.regression:
+            cv_splitter = KFold(n_splits=cv_folds, shuffle=shuffle)
+        else:
+            cv_splitter = StratifiedKFold(n_splits=cv_folds, shuffle=shuffle)
         scores = cross_val_score(est, X_train_np, y_train_np, scoring=scorer,
-                                 cv=strat_k_fold, n_jobs=n_jobs, verbose=verbosity)
+                                 cv=cv_splitter, n_jobs=n_jobs, verbose=verbosity)
         logger.info("Cross-Validation Scores: %s", scores)
 
     # Store the estimator

--- a/alphapy/plots.py
+++ b/alphapy/plots.py
@@ -69,6 +69,7 @@ from sklearn.inspection import PartialDependenceDisplay
 from sklearn.metrics import auc
 from sklearn.metrics import confusion_matrix
 from sklearn.metrics import roc_curve
+from sklearn.model_selection import KFold
 from sklearn.model_selection import learning_curve
 from sklearn.model_selection import StratifiedKFold
 from sklearn.model_selection import validation_curve
@@ -476,6 +477,7 @@ def plot_learning_curve(alphapy_specs, model, partition):
     # Extract model parameters.
 
     cv_folds = model.specs['cv_folds']
+    model_type = model.specs['model_type']
     n_jobs = model.specs['n_jobs']
     shuffle = model.specs['shuffle']
     verbosity = model.specs['verbosity']
@@ -488,7 +490,10 @@ def plot_learning_curve(alphapy_specs, model, partition):
     X, y = get_partition_data(model, partition)
 
     # Set cross-validation parameters to get mean train and test curves.
-    cv = StratifiedKFold(n_splits=cv_folds, shuffle=shuffle)
+    if model_type == ModelType.regression:
+        cv = KFold(n_splits=cv_folds, shuffle=shuffle)
+    else:
+        cv = StratifiedKFold(n_splits=cv_folds, shuffle=shuffle)
 
     # Plot a learning curve for each algorithm.
 

--- a/alphapy/transforms.py
+++ b/alphapy/transforms.py
@@ -282,7 +282,10 @@ def dateparts(df, c):
         The dataframe containing the date features.
     """
 
-    ds_dt = pd.to_datetime(df[c])
+    col = df[c]
+    if hasattr(col, "to_pandas"):
+        col = col.to_pandas()
+    ds_dt = pd.to_datetime(col)
     date_features = pd.DataFrame()
     try:
         fyear = pd.Series(ds_dt.dt.year, name='year').astype(int)


### PR DESCRIPTION
## Summary
Three latent bugs surfaced when smoke-testing the \`projects/time-series\` example (regression workflow):

1. **\`transforms.dateparts\`** crashed on polars columns (\`'String' object has no attribute 'kind'\`).
2. **\`features.apply_transforms\`** raised TypeError when concatenating polars X with pandas transform output.
3. **\`model.first_fit\`** and **\`plots.generate_learning_curves\`** hardcoded \`StratifiedKFold\` — sklearn rejects this for continuous targets.

All three fixed: pandas/polars boundary coercion in the first two, and \`KFold\` vs \`StratifiedKFold\` switch on \`ModelType.regression\` in the last two.

## Test plan
- [x] \`pytest tests/\` → 18 passed, 1 skipped
- [x] \`cd projects/kaggle && alphapy\` → end-to-end (classification)
- [x] \`cd projects/pizza && alphapy\` → end-to-end (multiclass)
- [x] \`cd projects/time-series && alphapy\` → end-to-end (regression)