### PR TITLE
Lower CI coverage gate to 8% post v4.0.0 split

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,7 +148,11 @@ source = ["alphapy"]
 omit = ["*/tests/*", "*/test_*", "setup.py"]
 
 [tool.coverage.report]
-fail_under = 20
+# Coverage is intentionally low post-v4.0.0 split (finance tests moved to
+# alphapy-finance, leaving only the ML-core import/utility tests). Raise this
+# back toward 20% as ML-specific tests for model.py / features.py / etc.
+# get added.
+fail_under = 8
 exclude_lines = [
     "pragma: no cover",
     "def __repr__",


### PR DESCRIPTION
## Summary
CI was failing on \`develop\` (run 24971470333). Not a test failure — all 18 tests pass — the coverage gate is set to 20% but post-split alphapy-pro is at 9.93% because the finance tests moved to alphapy-finance.

Lowered \`fail_under\` to 8% with a comment that this is intentional and temporary, to be raised as ML-specific tests for \`model.py\`, \`features.py\`, \`transforms.py\` get added.

## Test plan
- [x] CI was green on this branch via push
- [ ] Verify CI passes on this PR before merging