### PR TITLE
Make alphapy CLI exit 0 on success

### DIFF
--- a/alphapy/alphapy_main.py
+++ b/alphapy/alphapy_main.py
@@ -708,9 +708,6 @@ def main(args=None):
     logger.info("AlphaPy End")
     logger.info('*'*80)
 
-    # Return the model
-    return model
-
 
 #
 # MAIN PROGRAM

--- a/alphapy/plots.py
+++ b/alphapy/plots.py
@@ -48,8 +48,6 @@
 #     2. Candlestick
 #
 
-print(__doc__)
-
 
 #
 # Imports


### PR DESCRIPTION
## Summary
Every successful `alphapy` run was exiting with code 1, masking real failures in CI and local pipeline checks. Two unrelated cosmetic bugs combined to produce this:

1. `main()` in `alphapy_main.py` ended with `return model`. The setuptools entry point wraps it as `sys.exit(main())`; passing a non-int non-None object to `sys.exit` stringifies to stderr and exits 1. No code calls `main()` programmatically (siblings use `main_pipeline` directly), so the `return` is vestigial. Dropped.

2. `plots.py` had a top-level `print(__doc__)` that printed the literal string `"None"` on every import (the file's "docstring" is `#`-comments, not a string, so `__doc__` is `None`). Dead noise since 2013. Removed.

## Test plan
- [x] `pytest tests/` — 23 passed
- [x] `cd projects/kaggle && uv run alphapy` — exit 0, clean output
- [x] `cd projects/pizza && uv run alphapy` — exit 0, clean output
- [x] `cd projects/time-series && uv run alphapy` — exit 0, clean output